### PR TITLE
Fixed french zero case

### DIFF
--- a/Plural Loc/fr.lproj/Localizable.stringsdict
+++ b/Plural Loc/fr.lproj/Localizable.stringsdict
@@ -13,7 +13,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>zero</key>
-			<string>%d bouteille de bière </string>
+			<string>%d bouteilles de bière </string>
 			<key>one</key>
 			<string>%d bouteille de bière </string>
 			<key>other</key>


### PR DESCRIPTION
0 (ordinal) in french language acts like plural so you need to add an s. (https://www.unicode.org/cldr/charts/34/supplemental/language_plural_rules.html)